### PR TITLE
Property validity checks, part 2

### DIFF
--- a/src/TypeVisitor.ts
+++ b/src/TypeVisitor.ts
@@ -478,9 +478,9 @@ export default class TypeVisitor {
       propertyType instanceof NumberType
     ) {
       return objectType; // String index. TODO: Add a test for this
-    } else if (objectType instanceof ObjectType && propertyName) {
-      let propertyValueType = objectType.fields[propertyName];
-      return propertyValueType || new UndefinedType();
+    } else if (propertyName) {
+      // General property references, including object properties and builtins of other types
+      return objectType.getPropertyType(propertyName) ?? new UndefinedType();
     }
 
     console.warn(

--- a/src/TypeVisitor.ts
+++ b/src/TypeVisitor.ts
@@ -265,7 +265,12 @@ export default class TypeVisitor {
   public getVariableType(variableName: string, node: t.Node): Type {
     let mapping = this.symbolTable.getMap();
     let type = mapping.get(variableName);
-    if (type == null) {
+    if (type != null) {
+      return type;
+    } else if (global.hasOwnProperty(variableName)) {
+      // This is a JS global (e.g. "console")
+      return new AnyType();
+    } else {
       report.addError(
         `Reference to unknown variable ${variableName}`,
         this.filename,
@@ -274,7 +279,6 @@ export default class TypeVisitor {
       );
       return new ErrorType(); // proceed on errors
     }
-    return type;
   }
 
   public setVariableType(variableName: string, newType: Type) {

--- a/src/TypeVisitor.ts
+++ b/src/TypeVisitor.ts
@@ -309,18 +309,13 @@ export default class TypeVisitor {
           let lhsIsVariable = t.isIdentifier(node.left.object);
 
           if (lhsIsVariable) {
+            // if the LHS is a variable, update its type
             if (
               lhsType instanceof ArrayType &&
               indexType instanceof NumberType
             ) {
-              // if the LHS is a variable, update its type
-              let newListType = new ArrayType(
-                UnionType.asNeeded([lhsType.elementType, rhsType]),
-              );
-              this.setVariableType(
-                (node.left.object as t.Identifier).name,
-                newListType,
-              );
+              // Extend the array type in-place to support circular types
+              lhsType.extend([rhsType], true);
             } else if (lhsType instanceof ObjectType && propertyName) {
               lhsType.fields[propertyName] = rhsType;
             } else {

--- a/src/symbolTable.ts
+++ b/src/symbolTable.ts
@@ -514,4 +514,10 @@ export class AnyType extends Type {
   public alwaysTrue(): boolean {
     return false;
   }
+  override getMethodReturnType(
+    _methodName: string,
+    _inputArgTypes: Type[],
+  ): Type | null {
+    return this;
+  }
 }

--- a/src/symbolTable.ts
+++ b/src/symbolTable.ts
@@ -307,8 +307,12 @@ export class ArrayType extends Type {
   }
 
   // Return an array type including the current + new types
-  public extend(newTypes: Type[]): ArrayType {
-    return new ArrayType(UnionType.asNeeded([this.elementType, ...newTypes]));
+  public extend(newTypes: Type[], inPlace?: boolean): ArrayType {
+    let newElemType = UnionType.asNeeded([this.elementType, ...newTypes]);
+    if (inPlace) {
+      this.elementType = newElemType;
+    }
+    return new ArrayType(newElemType);
   }
 
   override getMethodReturnTypeMap(inputArgTypes: Type[]): TypeMap {

--- a/src/symbolTable.ts
+++ b/src/symbolTable.ts
@@ -22,7 +22,7 @@ export default class SymbolTable {
 
 // types
 export abstract class Type {
-  type = this.toString(); // used to determine deep equality
+  type = this.constructor.name; // used to determine deep equality
   public abstract toString(): string;
 
   public abstract isIterable(): boolean;
@@ -56,7 +56,7 @@ export abstract class Type {
 // base types
 export class NumberType extends Type {
   public toString() {
-    return "number";
+    return "NumberType";
   }
 
   public isIterable(): boolean {
@@ -87,7 +87,7 @@ export class NumberType extends Type {
 
 export class StringType extends Type {
   public toString() {
-    return "string";
+    return "StringType";
   }
 
   public isIterable(): boolean {
@@ -150,7 +150,7 @@ export class StringType extends Type {
 
 export class BooleanType extends Type {
   public toString() {
-    return "boolean";
+    return "BooleanType";
   }
 
   public isIterable(): boolean {
@@ -177,7 +177,7 @@ export class BooleanType extends Type {
 
 export class UndefinedType extends Type {
   public toString() {
-    return "undefined";
+    return "UndefinedType";
   }
 
   public isIterable(): boolean {
@@ -197,7 +197,7 @@ export class UndefinedType extends Type {
 
 export class NullType extends Type {
   public toString() {
-    return "null";
+    return "NullType";
   }
 
   public isIterable(): boolean {
@@ -219,7 +219,7 @@ export class NullType extends Type {
 export class ObjectType extends Type {
   public fields: TypeMap;
   public toString() {
-    return `object with fields: ${this.fields}`;
+    return `ObjectType[${this.fields}]`;
   }
 
   constructor(fields: TypeMap) {
@@ -248,7 +248,7 @@ export class ObjectType extends Type {
   override getMethodReturnTypeMap(_inputArgTypes: Type[]): TypeMap {
     return {
       // I'm ignoring the __ methods for now
-      // FIXME: add support for object methods
+      // FIXME: add support for object methods (custom types)
       hasOwnProperty: new BooleanType(),
       isPrototypeOf: new BooleanType(),
       propertyIsEnumerable: new BooleanType(),
@@ -262,7 +262,7 @@ export class ObjectType extends Type {
 export class ArrayType extends Type {
   public elementType: Type;
   public toString() {
-    return `array of ${this.elementType}`;
+    return `ArrayType[${this.elementType}]`;
   }
 
   constructor(elementType: Type) {
@@ -362,7 +362,7 @@ export class FunctionType extends Type {
   public params: Type[];
   public returnType: Type;
   public toString() {
-    return `function with parameter types ${this.params} and return type ${this.returnType}`;
+    return `FunctionType[${this.params} => ${this.returnType}]`;
   }
 
   constructor(params: Type[], returnType: Type) {
@@ -391,7 +391,7 @@ export class FunctionType extends Type {
 export class UnionType extends Type {
   public types: Type[];
   public toString() {
-    return `one of the following types ${this.types}`;
+    return `UnionType[${this.types.join("|")}]`;
   }
 
   // Union constructor that normalizes nested unions, removes duplicates, and strips unions of 1 type
@@ -474,7 +474,7 @@ export class UnionType extends Type {
 
 export class ErrorType extends Type {
   public toString() {
-    return "error-type";
+    return "ErrorType";
   }
 
   public isIterable(): boolean {
@@ -494,7 +494,7 @@ export class ErrorType extends Type {
 
 export class AnyType extends Type {
   public toString() {
-    return "any type";
+    return "AnyType";
   }
 
   public isIterable(): boolean {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -301,6 +301,24 @@ describe("Integration Tests", () => {
     assert.deepEqual(symbolTable.get("lst2"), lst2Type);
   });
 
+  it("Lists: recursive nested list + type mutation", () => {
+    let symbolTable = typecheckFiles([
+      "./test/test-examples/lists-nested-type-mutation-recursive.js",
+    ]).getMap();
+
+    // console.log(report.getErrors());
+    console.log(symbolTable);
+    assert.equal(report.getErrors().length, 0, "Expected 0 errors generated");
+
+    let lst1Type = new ArrayType(new StringType());
+    lst1Type.extend([lst1Type], true); // circular references BAYBEE
+    let lst2Type = new ArrayType(lst1Type);
+    assert.equal(symbolTable.size, 2);
+
+    assert.deepEqual(symbolTable.get("lst1"), lst1Type);
+    assert.deepEqual(symbolTable.get("lst2"), lst2Type);
+  });
+
   it("Lists: instance methods with type side-effects", () => {
     let symbolTable = typecheckFiles([
       "./test/test-examples/lists-methods-side-effects.js",

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -141,6 +141,38 @@ describe("Integration Tests", () => {
     );
   });
 
+  it("Objects: property name coalescing", () => {
+    let symbolTable = typecheckFiles([
+      "./test/test-examples/objects-property-name-coalescing.js",
+    ]).getMap();
+    assert.equal(report.isEmpty(), true, "Expected error report to be empty");
+
+    let objType = new ObjectType({
+      "1": new StringType(),
+      two: new NumberType(),
+      "3": new StringType(),
+      four: new NumberType(),
+    });
+    assert.equal(symbolTable.size, 1);
+    assert.deepEqual(symbolTable.get("obj"), objType);
+  });
+
+  it("Objects: circular/recursive structure", () => {
+    let symbolTable = typecheckFiles([
+      "./test/test-examples/objects-circular-reference.js",
+    ]).getMap();
+    console.log(report.getErrors());
+    assert.equal(report.isEmpty(), true, "Expected error report to be empty");
+
+    let objType = new ObjectType({
+      "1": new NumberType(),
+      "3": new StringType(),
+    });
+    objType.fields["self"] = objType;
+    assert.equal(symbolTable.size, 1);
+    assert.deepEqual(symbolTable.get("a"), objType);
+  });
+
   it("Lists: should spread iterables", () => {
     let symbolTable = typecheckFiles([
       "./test/test-examples/lists-supported-spread.js",

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -44,6 +44,21 @@ describe("Integration Tests", () => {
     );
   });
 
+  it("Simple assignment with console.log", () => {
+    let symbolTable = typecheckFiles([
+      "./test/test-examples/simple-assignment-with-logging.js",
+    ]).getMap();
+    assert.equal(report.isEmpty(), true, "Error report should be empty");
+
+    assert.deepEqual(
+      symbolTable,
+      new Map([
+        ["x", new NumberType()],
+        ["y", new StringType()],
+      ]),
+    );
+  });
+
   it("Variable declaration: unknown variable", () => {
     let symbolTable = typecheckFiles([
       "./test/test-examples/declaration-error-unknown-var.js",

--- a/test/test-examples/lists-nested-methods.js
+++ b/test/test-examples/lists-nested-methods.js
@@ -1,0 +1,5 @@
+let lst1 = ["foo", "bar", "baz", ["abc", 555]];
+let lst2 = [lst1, 1, "foo", 3]
+
+let x = lst1.slice(3)
+let y = lst2[0].slice(3)  // error!

--- a/test/test-examples/lists-nested-properties.js
+++ b/test/test-examples/lists-nested-properties.js
@@ -1,0 +1,12 @@
+let lst = ["foo", "bar", "baz", ["abc", "def"]];
+let lst2 = [lst, 1, 2, 3]
+
+let w = lst[0];
+let x = lst.length;
+
+let y1 = w.length;      // this is allowed as arrays and strings both impl. length
+let y2 = lst[0].length; // same as y1
+
+let z = lst2[0].length; // undefined as number has no .length
+
+console.log(x, y1, y2, z);

--- a/test/test-examples/lists-nested-type-mutation-recursive.js
+++ b/test/test-examples/lists-nested-type-mutation-recursive.js
@@ -1,0 +1,7 @@
+// This starts as Array[String]
+let lst1 = ["foo", "bar"];
+// This starts as Array[Array[String]]
+let lst2 = [lst1]
+
+// This makes lst1 a circular array, which our code surprisingly handles???
+lst1[2] = lst2[0]

--- a/test/test-examples/lists-nested-type-mutation.js
+++ b/test/test-examples/lists-nested-type-mutation.js
@@ -1,0 +1,8 @@
+// This starts as Array[Union[String|Array[String|Number]]]
+let lst1 = ["foo", "bar", "baz", ["abc", 555]];
+// This starts as Array[Array[Union[String|Array[String|Number]]]]
+let lst2 = [lst1]
+
+// lst1 becomes Array[Union[String|Array[String|Number]|Number]]
+// lst2 becomes Array[Array[Union[String|Array[String|Number]|Number]]]
+lst1.push(1)

--- a/test/test-examples/objects-circular-reference.js
+++ b/test/test-examples/objects-circular-reference.js
@@ -1,0 +1,4 @@
+a = {1: 2, 3: "foo"}
+a.self = a
+
+console.log(a)

--- a/test/test-examples/objects-property-name-coalescing.js
+++ b/test/test-examples/objects-property-name-coalescing.js
@@ -1,0 +1,4 @@
+// Even though the key is a number literal, it will be casted to a string
+let obj = {1: "one", two: 2};
+obj[3] = "three"
+obj.four = 4

--- a/test/test-examples/simple-assignment-with-logging.js
+++ b/test/test-examples/simple-assignment-with-logging.js
@@ -1,0 +1,5 @@
+let x = 4;
+let y = "hello";
+
+console.log("x is set to " + x);
+console.log("y is set to " + y);


### PR DESCRIPTION
Roughly:
- Silence errors on accessing JS globals and their instance methods
- Implement property references for builtin types
- Refactor toString output to be more concise
- Make changes to Array element types in place (support 

For objects we don't know the type of (AnyType), I've opted to make the code silently accept all properties, as we'd get a whole lot of spurious errors that can't be overridden otherwise.