### PR TITLE
Scoping with Block Statements

### DIFF
--- a/src/TypeVisitor.ts
+++ b/src/TypeVisitor.ts
@@ -58,16 +58,6 @@ export default class TypeVisitor {
     }
   }
 
-  private visitBlockStatement(node: t.BlockStatement) {
-    this.symbolTable = new SymbolTable(this.symbolTable);
-    node.body.forEach((stmt) => this.visitStatement(stmt));
-    if (this.symbolTable.getParentScope() == null) {
-      throw new Error("Mismatched scope");
-    }
-    this.symbolTable.overwriteUpOne();
-    this.symbolTable = this.symbolTable.getParentScope() as SymbolTable;
-  }
-
   visitExpression(node: t.Expression): Type {
     console.log(`visit: seeing a ${node.type}`);
     switch (node.type) {
@@ -562,5 +552,15 @@ export default class TypeVisitor {
       );
       return new AnyType();
     }
+  }
+
+  private visitBlockStatement(node: t.BlockStatement) {
+    this.symbolTable = new SymbolTable(this.symbolTable);
+    node.body.forEach((stmt) => this.visitStatement(stmt));
+    if (this.symbolTable.getParentScope() == null) {
+      throw new Error("Mismatched scope");
+    }
+    this.symbolTable.overwriteUpOne();
+    this.symbolTable = this.symbolTable.getParentScope() as SymbolTable;
   }
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -373,9 +373,10 @@ describe("Integration Tests", () => {
 
     assert.equal(report.isEmpty(), true, "Expected no errors in report");
 
-    assert.equal(symbolTable.size, 2);
+    assert.equal(symbolTable.size, 3);
 
     assert.deepEqual(symbolTable.get("a"), new NumberType());
     assert.deepEqual(symbolTable.get("b"), new StringType());
+    assert.deepEqual(symbolTable.get("c"), new StringType());
   });
 });

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -365,4 +365,17 @@ describe("Integration Tests", () => {
     assert.deepEqual(symbolTable.get("newlen"), new NumberType());
     assert.deepEqual(symbolTable.get("first"), unionType);
   });
+
+  it("Block Scope: simple block scope", () => {
+    let symbolTable = typecheckFiles([
+      "./test/test-examples/block-scope.js",
+    ]).getMap();
+
+    assert.equal(report.isEmpty(), true, "Expected no errors in report");
+
+    assert.equal(symbolTable.size, 2);
+
+    assert.deepEqual(symbolTable.get("a"), new NumberType());
+    assert.deepEqual(symbolTable.get("b"), new StringType());
+  });
 });

--- a/test/test-examples/block-scope.js
+++ b/test/test-examples/block-scope.js
@@ -9,3 +9,10 @@ let b = true;
 {
   b = "string";
 }
+
+let c = 5;
+
+{
+  c = "string";
+  let c = true;
+}

--- a/test/test-examples/block-scope.js
+++ b/test/test-examples/block-scope.js
@@ -1,0 +1,11 @@
+let a = 4;
+
+{
+  let a = "string";
+}
+
+let b = true;
+
+{
+  b = "string";
+}

--- a/test/test-examples/objects-circular-reference.js
+++ b/test/test-examples/objects-circular-reference.js
@@ -1,4 +1,4 @@
-a = {1: 2, 3: "foo"}
+let a = {1: 2, 3: "foo"}
 a.self = a
 
 console.log(a)


### PR DESCRIPTION
Implemented block statements.

Handle aliasing through keeping two mappings, one of the locally declared variables, one of the variables declared in a parent scope but modified within this scope.

closes #34 